### PR TITLE
Allow to use JSX without '--jsx' flag

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18280,10 +18280,6 @@ namespace ts {
 
         function checkJsxPreconditions(errorNode: Node) {
             // Preconditions for using JSX
-            if ((compilerOptions.jsx || JsxEmit.None) === JsxEmit.None) {
-                error(errorNode, Diagnostics.Cannot_use_JSX_unless_the_jsx_flag_is_provided);
-            }
-
             if (getJsxElementTypeAt(errorNode) === undefined) {
                 if (noImplicitAny) {
                     error(errorNode, Diagnostics.JSX_element_implicitly_has_type_any_because_the_global_type_JSX_Element_does_not_exist);

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4189,10 +4189,6 @@
         "category": "Error",
         "code": 17003
     },
-    "Cannot use JSX unless the '--jsx' flag is provided.": {
-        "category": "Error",
-        "code": 17004
-    },
     "A constructor cannot contain a 'super' call when its class extends 'null'.": {
         "category": "Error",
         "code": 17005


### PR DESCRIPTION
Checklist:
* [X] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [ ] You've signed the CLA
* [ ] Ask if this is actually needed
* [ ] Run `jake runtests` locally
* [ ] There are new or updated unit tests validating the change


